### PR TITLE
PLANET-4068 Add onBefore & onReady scripts

### DIFF
--- a/backstop.json
+++ b/backstop.json
@@ -12,6 +12,8 @@
       "height": 768
     }
   ],
+  "onBeforeScript": "planet4/onBefore.js",
+  "onReadyScript": "planet4/onReady.js",
   "scenarios": [
     {
       "label": "Homepage",
@@ -19,7 +21,7 @@
       "referenceUrl": "",
       "readyEvent": "",
       "readySelector": "",
-      "delay": 5000,
+      "delay": 1000,
       "hideSelectors": [],
       "removeSelectors": [],
       "hoverSelector": "",

--- a/backstop_data/engine_scripts/planet4/onBefore.js
+++ b/backstop_data/engine_scripts/planet4/onBefore.js
@@ -52,8 +52,17 @@ module.exports = async function (page, scenario, vp) {
                 if (typeof (element) != 'undefined' && element != null) {
                     console.log('found carousel header block');
                     element.removeAttribute('data-carousel-autoplay');
+                    // Pause carousel header button animation.
+                    element.querySelector('.action-button').style.WebkitAnimationPlayState = "paused";
+                    element.querySelector('.action-button').style.animationPlayState = "paused";
                 }
                 console.log('DOMContentLoaded');
+
+                // Set global dataLayer variable to blacklist tag manager modules.
+                // Blacklist hotjar module.
+                window.dataLayer = [{
+                    'gtm.blacklist': ['hjtc']
+                }];
             });
         }
     }, scenario);

--- a/backstop_data/engine_scripts/planet4/onBefore.js
+++ b/backstop_data/engine_scripts/planet4/onBefore.js
@@ -1,0 +1,66 @@
+module.exports = async function (page, scenario, vp) {
+
+    console.log('-------onBefore script-------');
+
+    // Add event handler for DOMContentLoaded event using puppeteer api.
+    page.on('domcontentloaded', async () => {
+
+        // Log DOMContentLoaded event.
+        console.log('DOMContentLoaded');
+
+        // Run snippet on DOMContentLoaded.
+        // 1. Find iframes.
+        // 2. if iframes have youtube as src set sandbox attribute to iframe
+        //    to stop youtube scripts from running.
+        page.evaluate(() => {
+            console.log('search for iframes');
+            let iframes = document.querySelectorAll('iframe');
+            iframes.forEach((iframe) => {
+                console.log('iframe');
+                if (iframe.src.match(/^(http(s)?:\/\/)?((w){3}.)?youtu(be|.be)?(-nocookie)?(\.com)?\/.+/) !== null) {
+                    iframe.sandbox.add('allow-forms');
+                    console.log(iframe.src);
+                }
+            });
+        });
+    });
+
+    // Add handler for every document that is created.
+    //
+    // From puppeteer documentation:
+    // The function is invoked after the document was created but before any of its scripts were run.
+    // This is useful to amend the JavaScript environment
+    page.evaluateOnNewDocument(async (scenario) => {
+        console.log('----------evaluateOnNewDocument------------');
+
+        document.addEventListener('readystatechange', () => {
+            console.log('readyState:' + document.readyState);
+        });
+
+
+        console.log('document location');
+        console.log(document.location.href);
+        if (document.location.href === scenario.url) {
+
+            // Add event handler for DOMContentLoaded event.
+            document.addEventListener('DOMContentLoaded', () => {
+
+                // Search for carousel header block using the wrapper element id.
+                var element = document.getElementById("carousel-wrapper-header");
+
+                //If carousel header element exists in the DOM, remove data-carousel-autoplay attribute to prevent autoplau.
+                if (typeof (element) != 'undefined' && element != null) {
+                    console.log('found carousel header block');
+                    element.removeAttribute('data-carousel-autoplay');
+                }
+                console.log('DOMContentLoaded');
+            });
+        }
+    }, scenario);
+
+
+    page.once('load', () => {
+        console.log('-----Page loaded!-----');
+    });
+
+};

--- a/backstop_data/engine_scripts/planet4/onReady.js
+++ b/backstop_data/engine_scripts/planet4/onReady.js
@@ -10,5 +10,20 @@ module.exports = async (page, scenario, vp) => {
             window.jQuery('.carousel').carousel('pause');
         }
     });
-    // await page.waitFor(10000);
+
+    // 1. Find img tags.
+    // 2. Create a Promise which is resolved until all images fire load event.
+    await page.evaluate(async () => {
+        const imgs = Array.from(document.querySelectorAll("img"));
+
+        if (imgs.length > 0) {
+            await Promise.all(imgs.map(img => {
+                if (img.complete) return;
+                return new Promise((resolve, reject) => {
+                    img.addEventListener('load', resolve);
+                    img.addEventListener('error', reject);
+                });
+            }));
+        }
+    });
 };

--- a/backstop_data/engine_scripts/planet4/onReady.js
+++ b/backstop_data/engine_scripts/planet4/onReady.js
@@ -1,0 +1,14 @@
+module.exports = async (page, scenario, vp) => {
+
+    console.log('-------onReady script-------');
+
+    await page.evaluate(() => {
+
+        // Pause boostrap carousel
+        // This targets planet4 gallery block.
+        if ('undefined' !== window.jQuery) {
+            window.jQuery('.carousel').carousel('pause');
+        }
+    });
+    // await page.waitFor(10000);
+};


### PR DESCRIPTION
Added onBefore and onReady scripts for backstopjs.

They include the below functionality:

- Pause gallery block slideshow (boostrap carousel)
- Remove autoplay for carousel header block
- Pause animation for carousel header block button.
- Wait until all img elements have fired load event, to ensure that all images are loaded and rendered.
- Blacklist hotjar module for google tag manager, to prevent usabilla from loading.
- Stop youtube iframes from running scripts, to prevent youtube videos thumbnail/overlays and controls.
