### PR TITLE
Grep backstop report for errors

### DIFF
--- a/backstop.json
+++ b/backstop.json
@@ -57,8 +57,8 @@
     "puppeteerOffscreenCaptureFix": true,
     "args": ["--no-sandbox"]
   },
-  "asyncCaptureLimit": 10,
-  "asyncCompareLimit": 50,
+  "asyncCaptureLimit": 5,
+  "asyncCompareLimit": 10,
   "debug": false,
   "debugWindow": false
 }

--- a/makecomparison.sh
+++ b/makecomparison.sh
@@ -1,23 +1,33 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -u
 
 ./replacevars.sh
 
 cp /app/backstop_data/* /src/backstop_data/ -R
 
-if (backstop test) then
-  testresult=0;
+# Instead of relying to backstop exit code
+# grep its output for ERROR
+# https://github.com/garris/BackstopJS/issues/1145
+echo "Running backstop"
+backstop test > /tmp/backstop_report.txt
+cat /tmp/backstop_report.txt
+
+# If report has a match for "ERROR" keep a fail status
+if [ "$(grep -c "ERROR" /tmp/backstop_report.txt)" == 0 ]; then
+  echo "✅ All passed"
+  testresult=0
 else
-  testresult=1;
-fi;
+  echo "❌ Errors found"
+  testresult=1
+fi
 
 cp /src/backstop_data/* /app/backstop_data/ -R
 
 #Get the git message for this commit
-git_message=$(git --git-dir=/src/repo/.git log --format=%B -n 1 $CIRCLE_SHA1)
-echo "The git message is :"
+git_message=$(git --git-dir=/src/repo/.git log --format=%B -n 1 "$CIRCLE_SHA1")
+echo "The git message is:"
 echo "-----------"
-echo $git_message;
+echo "$git_message"
 echo "-----------"
 echo "The testresult is $testresult"
 
@@ -25,19 +35,19 @@ echo "The testresult is $testresult"
 #     if tests are successfull and you find the text [AUTO-PROCEED] in the commit message,
 #      trigger the workflow 'release-finish'
 #      else trigger the workflow 'release-hold-and-finish'
-if [ $APP_ENVIRONMENT = 'staging' ]; then
+if [ "$APP_ENVIRONMENT" = "staging" ]; then
   if [ $testresult = 0 ]  && [[ $git_message == *"[AUTO-PROCEED]"* ]]; then
     echo "The auto-proceed message exists and the testresult is 0"
     #Parameter 3 is release_init
     #Parameter 4 is release_hold
     #Parameter 5 is release_finish
-    ./trigger_api.sh $CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH false false true
+    ./trigger_api.sh "$CIRCLE_PROJECT_REPONAME" "$CIRCLE_BRANCH" false false true
   else
     echo "Either the auto-proceed does not exist or the testresult is not 0"
     #Parameter 3 is release_init
     #Parameter 4 is release_hold
     #Parameter 5 is release_finish
-    ./trigger_api.sh $CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH false true false
+    ./trigger_api.sh "$CIRCLE_PROJECT_REPONAME" "$CIRCLE_BRANCH" false true false
   fi;
 fi;
 


### PR DESCRIPTION
TL;DR: Instead of relying to backstop exit code, grep its output for `ERROR`. I added more context in the [ticket](https://jira.greenpeace.org/browse/PLANET-5100).

[Upstream bug](https://github.com/garris/BackstopJS/issues/1145)