### PR TITLE
PLANET-5141 Adjust comparison script for new Release flow

### DIFF
--- a/makecomparison.sh
+++ b/makecomparison.sh
@@ -23,7 +23,7 @@ fi
 
 cp /src/backstop_data/* /app/backstop_data/ -R
 
-#Get the git message for this commit
+# Get the git message for this commit
 git_message=$(git --git-dir=/src/repo/.git log --format=%B -n 1 "$CIRCLE_SHA1")
 echo "The git message is:"
 echo "-----------"
@@ -32,23 +32,11 @@ echo "-----------"
 echo "The testresult is $testresult"
 
 # if the APP_ENVIRONMENT is staging AND
-#     if tests are successfull and you find the text [AUTO-PROCEED] in the commit message,
-#      trigger the workflow 'release-finish'
-#      else trigger the workflow 'release-hold-and-finish'
-if [ "$APP_ENVIRONMENT" = "staging" ]; then
-  if [ $testresult = 0 ]  && [[ $git_message == *"[AUTO-PROCEED]"* ]]; then
-    echo "The auto-proceed message exists and the testresult is 0"
-    #Parameter 3 is release_init
-    #Parameter 4 is release_hold
-    #Parameter 5 is release_finish
-    ./trigger_api.sh "$CIRCLE_PROJECT_REPONAME" "$CIRCLE_BRANCH" false false true
-  else
-    echo "Either the auto-proceed does not exist or the testresult is not 0"
-    #Parameter 3 is release_init
-    #Parameter 4 is release_hold
-    #Parameter 5 is release_finish
-    ./trigger_api.sh "$CIRCLE_PROJECT_REPONAME" "$CIRCLE_BRANCH" false true false
-  fi;
-fi;
+# there is a [HOLD] in the commit message,
+# mark job as failed
+if [ "$APP_ENVIRONMENT" = 'staging' ] && [[ "$git_message" == *"[HOLD]"* ]]; then
+  echo "Failing the job since there is a [HOLD] prefix"
+  exit 1
+fi
 
-exit $testresult;
+exit $testresult


### PR DESCRIPTION
- Reverse promotion logic: auto-promote by default, use [HOLD] to block that.
- Remove trigger api steps. This will be done in the next job. Just adjust exit code.