### PR TITLE
PLANET-5409 promote in compare job

### DIFF
--- a/makecomparison.sh
+++ b/makecomparison.sh
@@ -9,7 +9,7 @@ cp /app/backstop_data/* /src/backstop_data/ -R
 # grep its output for ERROR
 # https://github.com/garris/BackstopJS/issues/1145
 echo "Running backstop"
-backstop test > /tmp/backstop_report.txt
+backstop test >/tmp/backstop_report.txt
 cat /tmp/backstop_report.txt
 
 # If report has a match for "ERROR" keep a fail status
@@ -31,15 +31,9 @@ echo "$git_message"
 echo "-----------"
 echo "The testresult is $testresult"
 
-if [ "$APP_ENVIRONMENT" = 'staging' ]; then
-  if [ $testresult -eq 1 ]; || [[ "$git_message" == *"[HOLD]"* ]]; then
-    # If on staging visual tests failed, trigger the Rollback workflow.
-    # Also trigger a rollback workflow if there is a hold prefix, as we expect a rollback might be needed.
-    ./trigger_rollback.sh "$CIRCLE_PROJECT_REPONAME" "$CIRCLE_TAG"
-  else
-    # if on staging visual tests pass, unhold the production pipeline.
-    ./promote.sh "$CIRCLE_WORKFLOW_ID"
-  fi
+if [ "$APP_ENVIRONMENT" = 'staging' ] && [ $testresult -eq 0 ] && [[ "$git_message" != *"[HOLD]"* ]]; then
+  # if on staging visual tests pass, unhold the production pipeline.
+  ./promote.sh "$CIRCLE_WORKFLOW_ID"
 fi
 
 exit $testresult

--- a/promote.sh
+++ b/promote.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ID="$1"
+echo "ID: ${ID}"
+
+url="https://circleci.com/api/v2/workflow/${ID}/job"
+
+# Get workflow details
+workflow=$(curl -s -u "${CIRCLE_TOKEN}": -X GET --header "Content-Type: application/json" "$url")
+
+# Get approval job id
+job_id=$(echo "$workflow" | jq -r '.items[] | select(.name=="hold-production") | .approval_request_id ')
+
+echo "Unholding production build after passing tests."
+echo "Job ID: ${job_id}"
+
+# Approve
+curl \
+  --header "Content-Type: application/json" \
+  -u "${CIRCLE_TOKEN}:" \
+  -X POST \
+  "https://circleci.com/api/v2/workflow/${ID}/approve/${job_id}"


### PR DESCRIPTION
Since we already trigger a rollback from the compare job, it makes sense to also include the promotion logic here. That way we win some time by not having to spin up a separate container to execute this. It also makes the pipeline a bit more compact.