### PR TITLE
Always exit properly if the job is finished

### DIFF
--- a/makecomparison.sh
+++ b/makecomparison.sh
@@ -31,9 +31,9 @@ echo "$git_message"
 echo "-----------"
 echo "The testresult is $testresult"
 
+# if on staging visual tests pass, unhold the production pipeline.
 if [ "$APP_ENVIRONMENT" = 'staging' ] && [ $testresult -eq 0 ] && [[ "$git_message" != *"[HOLD]"* ]]; then
-  # if on staging visual tests pass, unhold the production pipeline.
   ./promote.sh "$CIRCLE_WORKFLOW_ID"
 fi
 
-exit $testresult
+exit 0


### PR DESCRIPTION
This will prevent release pipelines from persisting in a failed state.

The visual indicator for checking the tests artifacts would be that hold job was not automatically approved.