### PR TITLE
Add a Slack notification script

### DIFF
--- a/makecomparison.sh
+++ b/makecomparison.sh
@@ -31,9 +31,15 @@ echo "$git_message"
 echo "-----------"
 echo "The testresult is $testresult"
 
-# if on staging visual tests pass, unhold the production pipeline.
-if [ "$APP_ENVIRONMENT" = 'staging' ] && [ $testresult -eq 0 ] && [[ "$git_message" != *"[HOLD]"* ]]; then
-  ./promote.sh "$CIRCLE_WORKFLOW_ID"
+# Some extra checks on staging
+if [ "$APP_ENVIRONMENT" = 'staging' ]; then
+  # if visual tests pass, unhold the production pipeline
+  # else notify on Slack
+  if [ $testresult -eq 0 ] && [[ "$git_message" != *"[HOLD]"* ]]; then
+    ./promote.sh "$CIRCLE_WORKFLOW_ID"
+  else
+    ./slack_notify.sh
+  fi
 fi
 
 exit 0

--- a/notify_slack.sh
+++ b/notify_slack.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -u
+
+MSG_TYPE=":red_circle: A visualtests-compare job has failed!"
+MSG_TITLE="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} @ ${CIRCLE_BRANCH:-${CIRCLE_TAG}}"
+MSG_LINK="https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_WORKSPACE_ID}"
+MSG_TEXT="Requires manual approval"
+MSG_COLOUR="#ff0000"
+
+json=$(jq -n \
+  --arg MSG_TYPE "$MSG_TYPE" \
+  --arg MSG_TITLE "$MSG_TITLE" \
+  --arg MSG_LINK "$MSG_LINK" \
+  --arg MSG_TEXT "$MSG_TEXT" \
+  --arg MSG_COLOUR "$MSG_COLOUR" \
+  '{
+  "text": $MSG_TYPE,
+  "attachments": [
+    {
+      "title": $MSG_TITLE,
+      "title_link": $MSG_LINK,
+      "text": $MSG_TEXT,
+      "color": $MSG_COLOUR
+    }
+  ]
+}')
+
+curl -X POST -H 'Content-Type: application/json' \
+  --data "$json" \
+  "${SLACK_NRO_WEBHOOK}"


### PR DESCRIPTION
Since we pass that job in any case, we can't rely on the slack orb.

This adds a simple script to notify Slack for a manual approval when required.