### PR TITLE
Add query string to all urls

### DIFF
--- a/createConfig.js
+++ b/createConfig.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+
+const baseConfig = JSON.parse(fs.readFileSync('backstop.json'));
+let localConfig;
+try {
+    localConfig = JSON.parse(fs.readFileSync('/src/repo/backstop-pages.json'));
+} catch (e) {
+    localConfig = {};
+}
+
+const addQueryString = scenario => {
+    const url = scenario.url.includes('?') ? scenario.url : `${scenario.url}?backstop=1`;
+
+    return {...scenario, url};
+};
+
+newConfig = {
+    ...baseConfig,
+    scenarios: [
+        ...baseConfig.scenarios,
+        ...(localConfig.scenarios || []),
+    ].map(addQueryString),
+    viewports: [
+        ...baseConfig.viewports,
+        ...(localConfig.viewports || []),
+    ],
+};
+
+fs.writeFileSync('backstop.json', JSON.stringify(newConfig, null, 2));
+
+

--- a/mergescenarios.sh
+++ b/mergescenarios.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ -f /src/repo/backstop-pages.json ]; then
-  jq 'reduce inputs.scenarios as $s (.; .scenarios += $s)' backstop.json /src/repo/backstop-pages.json > combined.json
-  jq 'reduce inputs.viewports as $s (.; .viewports += $s)' combined.json /src/repo/backstop-pages.json > combined2.json
+local_config=/src/repo/backstop-pages.json
 
-  mv backstop.json backstop-backup.json
-  mv combined2.json backstop.json
+if [ -f $local_config ]; then
+
+  cp backstop.json backstop-backup.json
+
+  node createConfig.js
+
+  git --no-pager diff backstop.json
 fi


### PR DESCRIPTION
* Use node script to avoid having to do all this in jq.

Adds a query string to the url, unless it already has one.

Tested on cidev: https://app.circleci.com/pipelines/github/greenpeace/planet4-cidev/944/workflows/dd98adf3-cf23-4f34-802c-245bfbd24d23/jobs/2684 and https://app.circleci.com/pipelines/github/greenpeace/planet4-cidev/947/workflows/c11b5352-f6d6-41a5-8047-0c895522a7a2/jobs/2690/artifacts