### PR TITLE
Use specific selectors for default scenarios

### DIFF
--- a/backstop.json
+++ b/backstop.json
@@ -34,13 +34,22 @@
       "label": "Homepage",
       "url": "https://APP_HOSTNAME/APP_HOSTPATH/",
       "delay": 3000,
-      "misMatchThreshold" : 1.5
+      "misMatchThreshold" : 1.5,
+      "selectors": [
+        "#header",
+        "#footer"
+      ]
     },
     {
       "label": "Search",
       "url": "https://APP_HOSTNAME/APP_HOSTPATH/?s=",
       "delay": 3000,
-      "misMatchThreshold" : 1.5
+      "misMatchThreshold" : 1.5,
+      "selectors": [
+        ".search-bar",
+        ".sort-filter",
+        "#filter-sidebar-options"
+      ]
     }
   ],
   "paths": {


### PR DESCRIPTION
For the only two default scenarios we run on all NROs, we can switch on using specific selectors, instead of testing the whole page, to avoid false negatives. 

For NROs that have heavily customized child themes, we can still add the full page scenarios in their scenarios. Since we use these tests in deployment as a sanity check, for NROs that use the vanilla theme checking specific selectors is sufficient. And we already have acceptance tests to check specific blocks.