### PR TITLE
Make error check case insensitive

### DIFF
--- a/makecomparison.sh
+++ b/makecomparison.sh
@@ -13,7 +13,7 @@ backstop test >/tmp/backstop_report.txt
 cat /tmp/backstop_report.txt
 
 # If report has a match for "ERROR" keep a fail status
-if [ "$(grep -c "ERROR" /tmp/backstop_report.txt)" == 0 ]; then
+if [ "$(grep -ci "ERROR" /tmp/backstop_report.txt)" == 0 ]; then
   echo "✅ All passed"
   testresult=0
 else


### PR DESCRIPTION
We had a [recent case](https://app.circleci.com/pipelines/github/greenpeace/planet4-storytelling/1276/workflows/603f23b9-59e7-43ed-bf21-23ce30a3ef8d/jobs/3653/steps), where the comparison failed because of missing assets. But the job passed because the error messages in this case starts with `Error` instead of `ERROR`.