### PR TITLE
Fix onReady timeout on happypoint iframe

### DIFF
--- a/backstop_data/engine_scripts/planet4/onBefore.js
+++ b/backstop_data/engine_scripts/planet4/onBefore.js
@@ -5,13 +5,11 @@ module.exports = async function (page, scenario, vp) {
     page.on('load', () => {
         console.log('-----Page loading-----');
 
-        // Remove iframes from the page
-        // to avoid happypoint issues
-        page.$$eval('iframe', (frames) => {
-            frames.map((frame) => {
-                console.log('Removing iframe');
-                frame.parentNode.removeChild(frame);
-            });
+        // Remove happypoint from the page
+        // to avoid timeout issues
+        page.$eval('#happy-point', (happypoint) => {
+            console.log('Removing happypoint');
+            happypoint.parentNode.removeChild(happypoint);
         });
     });
 


### PR DESCRIPTION
Backstop reference job is failing with a timeout on specific pages
- https://app.circleci.com/pipelines/github/greenpeace/planet4-brasil/1293/workflows/dfba697a-3fef-411b-9d87-fc33e538ce0f
- https://app.circleci.com/pipelines/github/greenpeace/planet4-colombia/1291/workflows/fb2b8e84-a846-43e2-8019-819383dee5ec

`TimeoutError: Navigation timeout of 240000 ms exceeded`


I tried 
- changing backstop configuration to limit memory usage (`asyncCaptureLimit` to 1, one scenario at a time)
- blocking various tracking scripts (google, optimonk, nr-data, etc.)
- editing iframes [content, timeout, waitUntil](https://pptr.dev/#?product=Puppeteer&version=v10.2.0&show=api-framesetcontenthtml-options) after loading

Blocking the `wp-polyfill.js` file was working, because it was breaking the happypoint.
I also tried blocking happypoint requests, but that didn't seem to work. Leaving the filtering code here in case we need it.
```js
    page.setRequestInterception(true);
    page.on('request', (request) => {
        const url = request.url();
        const filters = [
            // 'googletagmanager',
            // 'optimonk',
            'happypoint'
        ];
        const shouldAbort = filters.some((urlPart) => url.includes(urlPart));
        console.log('Request', request.method(), request.url());
        if (shouldAbort) {
            console.log('Blocked: ' + request.url());
            request.abort();
        }
        else request.continue();
    });
```

In the end, removing the iframes during loading seems to work.
We were already hiding those in the [`onReady.js`](https://github.com/greenpeace/planet4-backstop/blob/35a5866fa53afef5317167b72ee4d67e10101d82/backstop_data/engine_scripts/planet4/onReady.js#L5) file, but this event is not triggered when the timeout issue happens.