### PR TITLE
Replace $ call with native js

### DIFF
--- a/backstop_data/engine_scripts/planet4/onReady.js
+++ b/backstop_data/engine_scripts/planet4/onReady.js
@@ -8,7 +8,7 @@ module.exports = async (page, scenario, vp) => {
         const iframes = document.querySelectorAll('iframe');
         iframes.forEach((iframe) => {
             console.log('[Ready] before: ' + iframe);
-            $(iframe).attr('src', '');
+            iframe.setAttribute('src', '');
             console.log('[Ready] after: ' + iframe.src);
         });
 


### PR DESCRIPTION
Cf. https://app.circleci.com/pipelines/github/greenpeace/planet4-switzerland/2409/workflows/79e8db0d-7d89-47ba-9af3-fd5e7bc29b23/jobs/8234

iframe removal can fail with error
```
Browser Console Log 0: JSHandle:[Ready] before: [object HTMLIFrameElement]
Puppeteer encountered an error while running scenario "Planet4 GPCH Explore (DE)"
Error: Evaluation failed: ReferenceError: $ is not defined
    at __puppeteer_evaluation_script__:5:13
    at NodeList.forEach (<anonymous>)
    at __puppeteer_evaluation_script__:3:17
```